### PR TITLE
build: add Geant4::G4OpenGL dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(source_files
 )
 
 add_library(g4ox ${source_files})
-target_link_libraries(g4ox PUBLIC Geant4::G4gdml Opticks::G4CX)
+target_link_libraries(g4ox PUBLIC Geant4::G4gdml Geant4::G4OpenGL Opticks::G4CX)
 
 target_include_directories(g4ox
     INTERFACE


### PR DESCRIPTION
This fixes the issue with geometry visualization when running this command:

```
GEOM=dummy build/src/simg4ox -g esi-g4ox/geom/pfrich_min.gdml -m esi-g4ox/vis.mac -i
```
However, the program now core dumps when running events:

```
GEOM=dummy build/src/simg4ox -g esi-g4ox/geom/pfrich_min.gdml -m esi-g4ox/run.mac
```

```
### Run 0 starts.
PhotonSD::Initialize:  MirrorPyramid_PhotonDetector   MirrorPyramid_PhotonDetector_HC
PhotonSD::EndOfEvent Number of PhotonHits: 0

Thread 1 "simg4ox" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00007f3721608bf4 in SEvt::gather_components (this=0x559bd90ee6d0) at /esi/opticks/sysrap/SEvt.cc:3485
#2  0x00007f3721609885 in SEvt::gather (this=0x559bd90ee6d0) at /esi/opticks/sysrap/SEvt.cc:3571
#3  0x00007f371bcea5f5 in QSim::simulate (this=0x559bd8fd8190, eventID=0, reset_=false) at /esi/opticks/qudarap/QSim.cc:372
#4  0x00007f37227af023 in G4CXOpticks::simulate (this=0x559bd8ef2460, eventID=0, reset_=false) at /esi/opticks/g4cx/G4CXOpticks.cc:457
#5  0x0000559bd73e2973 in EventAction::EndOfEventAction(G4Event const*) ()
#6  0x00007f3721d92700 in G4EventManager::DoProcessing(G4Event*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4event.so
#7  0x00007f3721e6e187 in G4RunManager::DoEventLoop(int, char const*, int) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4run.so
#8  0x00007f3721e6c0b2 in G4RunManager::BeamOn(int, char const*, int) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4run.so
#9  0x00007f3721e95bf1 in G4RunMessenger::SetNewValue(G4UIcommand*, G4String) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4run.so
#10 0x00007f372303bdef in G4UIcommand::DoIt(G4String) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4intercoms.so
#11 0x00007f3723059eca in G4UImanager::ApplyCommand(char const*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4intercoms.so
#12 0x00007f37220c57af in G4VBasicShell::ExecuteCommand(G4String const&) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4interfaces.so
#13 0x00007f37220ca559 in G4VBasicShell::ApplyShellCommand(G4String const&, bool&, bool&) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4interfaces.so
#14 0x00007f37220fb08e in G4UIQt::ButtonCallback(QString const&) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4interfaces.so
#15 0x00007f3722c38204 in ?? () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Core.so.5
#16 0x00007f371dc45c16 in QAction::triggered(bool) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#17 0x00007f371dc4890c in QAction::activate(QAction::ActionEvent) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#18 0x00007f371dd43c9a in ?? () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#19 0x00007f371dd43dfb in QAbstractButton::mouseReleaseEvent(QMouseEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#20 0x00007f371de4123e in QToolButton::mouseReleaseEvent(QMouseEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#21 0x00007f371dc8f8be in QWidget::event(QEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#22 0x00007f371dc4c743 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#23 0x00007f371dc542f9 in QApplication::notify(QObject*, QEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#24 0x00007f3722bff188 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Core.so.5
#25 0x00007f371dc52e13 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#26 0x00007f371dca9017 in ?? () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#27 0x00007f371dcac2c5 in ?? () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#28 0x00007f371dc4c743 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Widgets.so.5
#29 0x00007f3722bff188 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Core.so.5
#30 0x00007f371d555acf in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Gui.so.5
#31 0x00007f371d52ad1c in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Gui.so.5
#32 0x00007f37140b32de in ?? () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/plugins/platforms/../../lib/libQt5XcbQpa.so.5
#33 0x00007f371d1b347b in g_main_dispatch () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/glib-2.78.3-rf4t3xsioshh3nqvngwx3ph3e2cttmjt/lib/libglib-2.0.so.0
#34 0x00007f371d1b6c40 in g_main_context_iterate_unlocked.constprop () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/glib-2.78.3-rf4t3xsioshh3nqvngwx3ph3e2cttmjt/lib/libglib-2.0.so.0
#35 0x00007f371d1b7503 in g_main_context_iteration () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/glib-2.78.3-rf4t3xsioshh3nqvngwx3ph3e2cttmjt/lib/libglib-2.0.so.0
#36 0x00007f3722c5b938 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Core.so.5
#37 0x00007f3722bfda9b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Core.so.5
#38 0x00007f3722c06444 in QCoreApplication::exec() () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/qt-5.15.15-2uzocosaxfi2zlh36yu3yuxt4cna4yc4/lib/libQt5Core.so.5
#39 0x00007f37220f4e1c in G4UIQt::SessionStart() () from /opt/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-11.4.0/geant4-11.2.2-wxgojamtundfmc7wetvfngvgqhfpjcij/lib/libG4interfaces.so
#40 0x0000559bd73be66f in main ()

```