### PR TITLE
Revert "fix: Change Geant4 11.2.2 component G4persistency -> G4gdml"

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: [gpu]
 
     container:
-      image: ghcr.io/bnlnpps/esi-shell:1.2.1-debug
+      image: ghcr.io/bnlnpps/esi-shell:1.2.2-debug
       volumes:
         - /usr/local/optix:/usr/local/optix
       options: -i -t

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(source_files
 )
 
 add_library(g4ox ${source_files})
-target_link_libraries(g4ox PUBLIC Geant4::G4gdml Opticks::G4CX)
+target_link_libraries(g4ox PUBLIC Geant4::G4persistency Opticks::G4CX)
 
 target_include_directories(g4ox
     INTERFACE


### PR DESCRIPTION
This reverts commit 6d9d3992530b0d68c5b9b13fc09077a518fe7597.

Due to crash when linking against Geant4 11.2.2 G4OpenGL library. Until this is understood and resolve, will use geant4@11.1.2